### PR TITLE
Plug in the actual Sass compiler

### DIFF
--- a/lib/src/dispatcher.dart
+++ b/lib/src/dispatcher.dart
@@ -23,9 +23,10 @@ class Dispatcher {
 
   /// Listens for incoming `CompileRequests` and passes them to [callback].
   ///
-  /// The callback must return a `CompileResponse` which is sent to the host. It
-  /// doesn't need to set [OutboundMessage_CompileResponse.id]; the [Dispatcher]
-  /// will take care of that.
+  /// The callback must return a `CompileResponse` which is sent to the host.
+  /// The callback may throw [ProtocolError]s, which will be sent back to the
+  /// host. Neither `CompileResponse`s nor [ProtocolError]s need to set their
+  /// `id` fields; the [Dispatcher] will take care of that.
   ///
   /// This may only be called once.
   void listen(

--- a/lib/src/utils.dart
+++ b/lib/src/utils.dart
@@ -1,0 +1,11 @@
+// Copyright 2019 Google Inc. Use of this source code is governed by an
+// MIT-style license that can be found in the LICENSE file or at
+// https://opensource.org/licenses/MIT.
+
+import 'embedded_sass.pb.dart';
+
+/// Returns a [ProtocolError] indicating that a mandatory field with the givne
+/// [fieldName] was missing.
+ProtocolError mandatoryError(String fieldName) => ProtocolError()
+  ..type = ProtocolError_ErrorType.PARAMS
+  ..message = "Missing mandatory field $fieldName";

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -13,6 +13,9 @@ executables:
 dependencies:
   async: ">=1.13.0 <3.0.0"
   protobuf: ^1.0.0
+  sass: ^1.21.0
+  source_maps: ^0.10.5
+  source_span: ^1.1.0
   stack_trace: ^1.6.0
   stream_channel: ">=1.6.0 <3.0.0"
 
@@ -21,3 +24,4 @@ dev_dependencies:
   protoc_plugin: ^19.0.0
   path: ^1.6.0
   test: ^1.0.0
+  test_descriptor: ^1.0.0

--- a/test/protocol_test.dart
+++ b/test/protocol_test.dart
@@ -2,7 +2,10 @@
 // MIT-style license that can be found in the LICENSE file or at
 // https://opensource.org/licenses/MIT.
 
+import 'package:path/path.dart' as p;
+import 'package:source_maps/source_maps.dart' as source_maps;
 import 'package:test/test.dart';
+import 'package:test_descriptor/test_descriptor.dart' as d;
 
 import 'package:sass_embedded/src/embedded_sass.pb.dart';
 
@@ -39,9 +42,236 @@ void main() {
     });
   });
 
-  test("compiles a CSS from a string", () async {
-    process.inbound.add(compileString("a {b: c}"));
-    await expectLater(process.outbound, emits(isSuccess("a { b: c; }")));
+  group("compiles CSS from", () {
+    test("an SCSS string by default", () async {
+      process.inbound.add(compileString("a {b: 1px + 2px}"));
+      await expectLater(process.outbound, emits(isSuccess("a { b: 3px; }")));
+      await process.kill();
+    });
+
+    test("an SCSS string explicitly", () async {
+      process.inbound.add(compileString("a {b: 1px + 2px}",
+          syntax: InboundMessage_Syntax.SCSS));
+      await expectLater(process.outbound, emits(isSuccess("a { b: 3px; }")));
+      await process.kill();
+    });
+
+    test("an indented syntax string", () async {
+      process.inbound.add(compileString("a\n  b: 1px + 2px",
+          syntax: InboundMessage_Syntax.INDENTED));
+      await expectLater(process.outbound, emits(isSuccess("a { b: 3px; }")));
+      await process.kill();
+    });
+
+    test("a plain CSS string", () async {
+      process.inbound
+          .add(compileString("a {b: c}", syntax: InboundMessage_Syntax.CSS));
+      await expectLater(process.outbound, emits(isSuccess("a { b: c; }")));
+      await process.kill();
+    });
+
+    test("an absolute path", () async {
+      await d.file("test.scss", "a {b: 1px + 2px}").create();
+
+      process.inbound.add(InboundMessage()
+        ..compileRequest = (InboundMessage_CompileRequest()
+          ..path = p.absolute(d.path("test.scss"))));
+      await expectLater(process.outbound, emits(isSuccess("a { b: 3px; }")));
+      await process.kill();
+    });
+
+    test("a relative path", () async {
+      await d.file("test.scss", "a {b: 1px + 2px}").create();
+
+      process.inbound.add(InboundMessage()
+        ..compileRequest = (InboundMessage_CompileRequest()
+          ..path = p.relative(d.path("test.scss"))));
+      await expectLater(process.outbound, emits(isSuccess("a { b: 3px; }")));
+      await process.kill();
+    });
+  });
+
+  group("compiles CSS in", () {
+    test("expanded mode", () async {
+      process.inbound.add(compileString("a {b: 1px + 2px}",
+          style: InboundMessage_CompileRequest_OutputStyle.EXPANDED));
+      await expectLater(
+          process.outbound, emits(isSuccess(equals("a {\n  b: 3px;\n}"))));
+      await process.kill();
+    });
+
+    test("compressed mode", () async {
+      process.inbound.add(compileString("a {b: 1px + 2px}",
+          style: InboundMessage_CompileRequest_OutputStyle.COMPRESSED));
+      await expectLater(process.outbound, emits(isSuccess(equals("a{b:3px}"))));
+      await process.kill();
+    });
+
+    test("expanded mode when nested mode is passed", () async {
+      process.inbound.add(compileString("a {b: 1px + 2px}",
+          style: InboundMessage_CompileRequest_OutputStyle.NESTED));
+      await expectLater(
+          process.outbound, emits(isSuccess(equals("a {\n  b: 3px;\n}"))));
+      await process.kill();
+    });
+
+    test("expanded mode when compact mode is passed", () async {
+      process.inbound.add(compileString("a {b: 1px + 2px}",
+          style: InboundMessage_CompileRequest_OutputStyle.COMPACT));
+      await expectLater(
+          process.outbound, emits(isSuccess(equals("a {\n  b: 3px;\n}"))));
+      await process.kill();
+    });
+  });
+
+  test("doesn't include a source map by default", () async {
+    process.inbound.add(compileString("a {b: 1px + 2px}"));
+    await expectLater(process.outbound,
+        emits(isSuccess("a { b: 3px; }", sourceMap: isEmpty)));
     await process.kill();
+  });
+
+  test("doesn't include a source map with source_map: false", () async {
+    process.inbound.add(compileString("a {b: 1px + 2px}", sourceMap: false));
+    await expectLater(process.outbound,
+        emits(isSuccess("a { b: 3px; }", sourceMap: isEmpty)));
+    await process.kill();
+  });
+
+  test("includes a source map if source_map is true", () async {
+    process.inbound.add(compileString("a {b: 1px + 2px}", sourceMap: true));
+    await expectLater(
+        process.outbound,
+        emits(isSuccess("a { b: 3px; }", sourceMap: predicate((map) {
+          var mapping = source_maps.parse(map);
+          var span = mapping.spanFor(2, 5);
+          expect(span.start.line, equals(0));
+          expect(span.start.column, equals(3));
+          expect(span.end, equals(span.start));
+          return true;
+        }))));
+    await process.kill();
+  });
+
+  group("gracefully handles an error", () {
+    test("from invalid syntax", () async {
+      process.inbound.add(compileString("a {b: }"));
+
+      var failure = getCompileFailure(await process.outbound.next);
+      expect(failure.message, equals("Expected expression."));
+      expect(failure.span.text, isEmpty);
+      expect(failure.span.start, equals(location(6, 0, 6)));
+      expect(failure.span.end, equals(location(6, 0, 6)));
+      expect(failure.span.url, isEmpty);
+      expect(failure.span.context, equals("a {b: }"));
+      expect(failure.stackTrace, equals("- 1:7  root stylesheet\n"));
+      await process.kill();
+    });
+
+    test("from the runtime", () async {
+      process.inbound.add(compileString("a {b: 1px + 1em}"));
+
+      var failure = getCompileFailure(await process.outbound.next);
+      expect(failure.message, equals("Incompatible units em and px."));
+      expect(failure.span.text, "1px + 1em");
+      expect(failure.span.start, equals(location(6, 0, 6)));
+      expect(failure.span.end, equals(location(15, 0, 15)));
+      expect(failure.span.url, isEmpty);
+      expect(failure.span.context, equals("a {b: 1px + 1em}"));
+      expect(failure.stackTrace, equals("- 1:7  root stylesheet\n"));
+      await process.kill();
+    });
+
+    test("from a missing file", () async {
+      process.inbound.add(InboundMessage()
+        ..compileRequest =
+            (InboundMessage_CompileRequest()..path = d.path("test.scss")));
+
+      var failure = getCompileFailure(await process.outbound.next);
+      expect(
+          failure.message, equals("Cannot open file: ${d.path('test.scss')}"));
+      expect(failure.span, equals(SourceSpan()));
+      expect(failure.stackTrace, isEmpty);
+      await process.kill();
+    });
+
+    test("with a multi-line source span", () async {
+      process.inbound.add(compileString("""
+a {
+  b: 1px +
+     1em;
+}
+"""));
+
+      var failure = getCompileFailure(await process.outbound.next);
+      expect(failure.span.text, "1px +\n     1em");
+      expect(failure.span.start, equals(location(9, 1, 5)));
+      expect(failure.span.end, equals(location(23, 2, 8)));
+      expect(failure.span.url, isEmpty);
+      expect(failure.span.context, equals("  b: 1px +\n     1em;\n"));
+      expect(failure.stackTrace, equals("- 2:6  root stylesheet\n"));
+      await process.kill();
+    });
+
+    test("with multiple stack trace entries", () async {
+      process.inbound.add(compileString("""
+@function fail() {
+  @return 1px + 1em;
+}
+
+a {
+  b: fail();
+}
+"""));
+
+      var failure = getCompileFailure(await process.outbound.next);
+      expect(
+          failure.stackTrace,
+          equals("- 2:11  fail()\n"
+              "- 6:6   root stylesheet\n"));
+      await process.kill();
+    });
+
+    group("and includes the URL from", () {
+      test("a string input", () async {
+        process.inbound
+            .add(compileString("a {b: 1px + 1em}", url: "foo://bar/baz"));
+
+        var failure = getCompileFailure(await process.outbound.next);
+        expect(failure.span.url, equals("foo://bar/baz"));
+        expect(
+            failure.stackTrace, equals("foo://bar/baz 1:7  root stylesheet\n"));
+        await process.kill();
+      });
+
+      test("a path input", () async {
+        await d.file("test.scss", "a {b: 1px + 1em}").create();
+        process.inbound.add(InboundMessage()
+          ..compileRequest =
+              (InboundMessage_CompileRequest()..path = d.path("test.scss")));
+
+        var failure = getCompileFailure(await process.outbound.next);
+        var url = p.toUri(d.path("test.scss"));
+        expect(failure.span.url, equals(url.toString()));
+        expect(failure.stackTrace,
+            equals("${p.prettyUri(url)} 1:7  root stylesheet\n"));
+        await process.kill();
+      });
+    });
+
+    test("caused by using Sass features in CSS", () async {
+      process.inbound.add(
+          compileString("a {b: 1px + 2px}", syntax: InboundMessage_Syntax.CSS));
+
+      var failure = getCompileFailure(await process.outbound.next);
+      expect(failure.message, equals("Operators aren't allowed in plain CSS."));
+      expect(failure.span.text, "+");
+      expect(failure.span.start, equals(location(10, 0, 10)));
+      expect(failure.span.end, equals(location(11, 0, 11)));
+      expect(failure.span.url, isEmpty);
+      expect(failure.span.context, equals("a {b: 1px + 2px}"));
+      expect(failure.stackTrace, equals("- 1:11  root stylesheet\n"));
+      await process.kill();
+    });
   });
 }

--- a/test/protocol_test.dart
+++ b/test/protocol_test.dart
@@ -188,8 +188,9 @@ void main() {
             (InboundMessage_CompileRequest()..path = d.path("test.scss")));
 
       var failure = getCompileFailure(await process.outbound.next);
-      expect(
-          failure.message, equals("Cannot open file: ${d.path('test.scss')}"));
+      expect(failure.message, startsWith("Cannot open file: "));
+      expect(failure.message.split(":").last.trim(),
+          equalsPath(d.path('test.scss')));
       expect(failure.span, equals(SourceSpan()));
       expect(failure.stackTrace, isEmpty);
       await process.kill();
@@ -251,8 +252,7 @@ a {
               (InboundMessage_CompileRequest()..path = d.path("test.scss")));
 
         var failure = getCompileFailure(await process.outbound.next);
-        var url = p.toUri(d.path("test.scss"));
-        expect(failure.span.url, equals(url.toString()));
+        expect(p.fromUri(failure.span.url), equalsPath(d.path("test.scss")));
         expect(failure.stackTrace,
             equals("${p.prettyUri(url)} 1:7  root stylesheet\n"));
         await process.kill();

--- a/test/protocol_test.dart
+++ b/test/protocol_test.dart
@@ -253,8 +253,8 @@ a {
 
         var failure = getCompileFailure(await process.outbound.next);
         expect(p.fromUri(failure.span.url), equalsPath(path));
-        expect(failure.stackTrace,
-            equals("${p.prettyUri(p.toUri(path))} 1:7  root stylesheet\n"));
+        expect(failure.stackTrace, endsWith(" 1:7  root stylesheet\n"));
+        expect(failure.stackTrace.split(" ").first, equalsPath(path));
         await process.kill();
       });
     });

--- a/test/protocol_test.dart
+++ b/test/protocol_test.dart
@@ -247,14 +247,14 @@ a {
 
       test("a path input", () async {
         await d.file("test.scss", "a {b: 1px + 1em}").create();
+        var path = d.path("test.scss");
         process.inbound.add(InboundMessage()
-          ..compileRequest =
-              (InboundMessage_CompileRequest()..path = d.path("test.scss")));
+          ..compileRequest = (InboundMessage_CompileRequest()..path = path));
 
         var failure = getCompileFailure(await process.outbound.next);
-        expect(p.fromUri(failure.span.url), equalsPath(d.path("test.scss")));
+        expect(p.fromUri(failure.span.url), equalsPath(path));
         expect(failure.stackTrace,
-            equals("${p.prettyUri(url)} 1:7  root stylesheet\n"));
+            equals("${p.prettyUri(p.toUri(path))} 1:7  root stylesheet\n"));
         await process.kill();
       });
     });

--- a/test/utils.dart
+++ b/test/utils.dart
@@ -93,6 +93,5 @@ SourceSpan_SourceLocation location(int offset, int line, int column) =>
 
 /// Returns a matcher that verifies whether the given value refers to the same
 /// path as [expected].
-Matcher equalsPath(String expected) =>
-    predicate<String>((actual) => p.equals(actual, expected),
-        description: "equals $path");
+Matcher equalsPath(String expected) => predicate<String>(
+    (actual) => p.equals(actual, expected), "equals $expected");

--- a/test/utils.dart
+++ b/test/utils.dart
@@ -10,9 +10,21 @@ import 'embedded_process.dart';
 
 /// Returns a [InboundMessage] that compiles the given plain CSS
 /// string.
-InboundMessage compileString(String css) => InboundMessage()
-  ..compileRequest = (InboundMessage_CompileRequest()
-    ..string = (InboundMessage_CompileRequest_StringInput()..source = css));
+InboundMessage compileString(String css,
+    {InboundMessage_Syntax syntax,
+    InboundMessage_CompileRequest_OutputStyle style,
+    String url,
+    bool sourceMap}) {
+  var input = InboundMessage_CompileRequest_StringInput()..source = css;
+  if (syntax != null) input.syntax = syntax;
+  if (url != null) input.url = url;
+
+  var request = InboundMessage_CompileRequest()..string = input;
+  if (style != null) request.style = style;
+  if (sourceMap != null) request.sourceMap = sourceMap;
+
+  return InboundMessage()..compileRequest = request;
+}
 
 /// Asserts that [process] emits a [ProtocolError] parse error with the given
 /// [message] on its protobuf stream and prints a notice on stderr.
@@ -36,7 +48,16 @@ Matcher isProtocolError(int id, ProtocolError_ErrorType type, [message]) =>
       return true;
     });
 
-/// Asserts that [message] is an [OutboundMessage] with a [CompileResponse] and
+/// Asserts that [message] is an [OutboundMessage] with a
+/// `CompileResponse.Failure` and returns it.
+OutboundMessage_CompileResponse_CompileFailure getCompileFailure(value) {
+  var response = getCompileResponse(value);
+  expect(response.hasFailure(), isTrue,
+      reason: "Expected $response to be a failure");
+  return response.failure;
+}
+
+/// Asserts that [message] is an [OutboundMessage] with a `CompileResponse` and
 /// returns it.
 OutboundMessage_CompileResponse getCompileResponse(value) {
   expect(value, isA<OutboundMessage>());
@@ -46,16 +67,25 @@ OutboundMessage_CompileResponse getCompileResponse(value) {
   return message.compileResponse;
 }
 
-/// Asserts that an [OutboundMessage] is a [CompileResponse] with CSS that
-/// matches [css].
+/// Asserts that an [OutboundMessage] is a `CompileResponse` with CSS that
+/// matches [css], with a source map that matches [sourceMap] (if passed).
 ///
 /// If [css] is a [String], this automatically wraps it in
 /// [equalsIgnoringWhitespace].
-Matcher isSuccess(css) => predicate((value) {
+Matcher isSuccess(css, {sourceMap}) => predicate((value) {
       var response = getCompileResponse(value);
       expect(response.hasSuccess(), isTrue,
           reason: "Expected $response to be successful");
       expect(response.success.css,
           css is String ? equalsIgnoringWhitespace(css) : css);
+      if (sourceMap != null) expect(response.success.sourceMap, sourceMap);
       return true;
     });
+
+/// Returns a [SourceSpan_SourceLocation] with the given [offset], [line], and
+/// [column].
+SourceSpan_SourceLocation location(int offset, int line, int column) =>
+    SourceSpan_SourceLocation()
+      ..offset = offset
+      ..line = line
+      ..column = column;

--- a/test/utils.dart
+++ b/test/utils.dart
@@ -2,6 +2,7 @@
 // MIT-style license that can be found in the LICENSE file or at
 // https://opensource.org/licenses/MIT.
 
+import 'package:path/path.dart' as p;
 import 'package:test/test.dart';
 
 import 'package:sass_embedded/src/embedded_sass.pb.dart';
@@ -89,3 +90,9 @@ SourceSpan_SourceLocation location(int offset, int line, int column) =>
       ..offset = offset
       ..line = line
       ..column = column;
+
+/// Returns a matcher that verifies whether the given value refers to the same
+/// path as [expected].
+Matcher equalsPath(String expected) =>
+    predicate<String>((actual) => p.equals(actual, expected),
+        description: "equals $path");

--- a/tool/grind.dart
+++ b/tool/grind.dart
@@ -25,7 +25,7 @@ pub run protoc_plugin %*
   } else {
     File('build/protoc-gen-dart')
         .writeAsStringSync('pub run protoc_plugin "\$@"');
-    runProcess('chmod', arguments: ['a+x', 'build/protoc-gen-dart']);
+    run('chmod', arguments: ['a+x', 'build/protoc-gen-dart']);
   }
 
   await cloneOrPull("git://github.com/sass/embedded-protocol");


### PR DESCRIPTION
This now supports real CompileRequest and CompileResponses, although
it's missing features like importers, custom functions, and source
maps.