### PR TITLE
Use the dart cli in tasks

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,9 +5,7 @@ branches:
   # Semantic version tags and legacy branches of the form "1.2.x".
   - "/^\\d+\\.\\d+\\.(\\d+([+-].*)?|x)$/"
 
-# TODO(nweiz): Make this stable when Dart 2.10.0 launches with a fix for
-# dart-lang/pub#2545.
-dart: 2.8.1
+dart: stable
 
 cache:
   directories:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -5,7 +5,7 @@ author: Sass Team
 homepage: https://github.com/sass/dart-sass-embedded
 
 environment:
-  sdk: '>=2.4.0 <3.0.0'
+  sdk: '>=2.10.0 <3.0.0'
 
 executables:
   dart-sass-embedded: dart_sass_embedded

--- a/tool/grind.dart
+++ b/tool/grind.dart
@@ -24,11 +24,11 @@ protobuf() async {
   if (Platform.isWindows) {
     File('build/protoc-gen-dart.bat').writeAsStringSync('''
 @echo off
-pub run protoc_plugin %*
+dart pub run protoc_plugin %*
 ''');
   } else {
     File('build/protoc-gen-dart')
-        .writeAsStringSync('pub run protoc_plugin "\$@"');
+        .writeAsStringSync('dart pub run protoc_plugin "\$@"');
     run('chmod', arguments: ['a+x', 'build/protoc-gen-dart']);
   }
 


### PR DESCRIPTION
When installing the Dart SDK on Ubuntu, the default behavior is to expose `dart` in the PATH but not the standalone tools (which are installed in `/usr/lib/dart/bin/` which is not in the PATH by default unlike `/usr/bin/`).

Using the `dart` tool makes the build process more portable.

Note that this requires having version 2.10+ of the SDK: https://dart.dev/tools/dart-tool