### PR TITLE
Implement --version flag for cli

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+## 1.0.0-beta.11
+
+* Add a `--version` flag that will print a `VersionResponse` as JSON, for ease
+  of human identification.
+
 ## 1.0.0-beta.10
 
 * Support version 1.0.0-beta.12 of the Sass embedded protocol:

--- a/README.md
+++ b/README.md
@@ -8,6 +8,11 @@ and importers.
 [Dart Sass]: https://sass-lang.com/dart-sass
 [Embedded Sass protocol]: https://github.com/sass/sass-embedded-protocol/blob/master/README.md#readme
 
+### Usage
+
+- `dart_sass_embedded` starts the compiler and listens on stdin.
+- `dart_sass_embedded --version` prints `versionResponse` with `id = 0` in JSON and exits.
+
 ### Releases
 
 Binary releases are available from the [GitHub release page]. We recommend that

--- a/bin/dart_sass_embedded.dart
+++ b/bin/dart_sass_embedded.dart
@@ -19,6 +19,14 @@ import 'package:sass_embedded/src/utils.dart';
 
 void main(List<String> args) {
   if (args.isNotEmpty) {
+    if (args.first == "--version") {
+      var response = Dispatcher.versionResponse();
+      response.id = 0;
+      stdout.writeln(
+          JsonEncoder.withIndent("  ").convert(response.toProto3Json()));
+      return;
+    }
+
     stderr.writeln(
         "This executable is not intended to be executed with arguments.\n"
         "See https://github.com/sass/embedded-protocol#readme for details.");

--- a/lib/src/dispatcher.dart
+++ b/lib/src/dispatcher.dart
@@ -57,16 +57,10 @@ class Dispatcher {
 
         switch (message.whichMessage()) {
           case InboundMessage_Message.versionRequest:
-            _send(OutboundMessage()
-              ..versionResponse = (OutboundMessage_VersionResponse()
-                ..protocolVersion =
-                    const String.fromEnvironment("protocol-version")
-                ..compilerVersion =
-                    const String.fromEnvironment("compiler-version")
-                ..implementationVersion =
-                    const String.fromEnvironment("implementation-version")
-                ..implementationName = "Dart Sass"
-                ..id = message.versionRequest.id));
+            var request = message.versionRequest;
+            var response = versionResponse();
+            response.id = request.id;
+            _send(OutboundMessage()..versionResponse = response);
             break;
 
           case InboundMessage_Message.compileRequest:
@@ -225,5 +219,15 @@ class Dispatcher {
       default:
         break;
     }
+  }
+
+  /// Creates a [OutboundMessage_VersionResponse]
+  static OutboundMessage_VersionResponse versionResponse() {
+    return OutboundMessage_VersionResponse()
+      ..protocolVersion = const String.fromEnvironment("protocol-version")
+      ..compilerVersion = const String.fromEnvironment("compiler-version")
+      ..implementationVersion =
+          const String.fromEnvironment("implementation-version")
+      ..implementationName = "Dart Sass";
   }
 }

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,5 +1,5 @@
 name: sass_embedded
-version: 1.0.0-beta.10
+version: 1.0.0-dev
 description: An implementation of the Sass embedded protocol using Dart Sass.
 author: Sass Team
 homepage: https://github.com/sass/dart-sass-embedded


### PR DESCRIPTION
Closes #31.

Although the embedded protocol can provide this information via VersionRequest, there is a chicken egg problem:

- Without making a VersionRequest, host doesn't know the correct protocol_version to use to talk to embedded.
- Without knowing the correct protocol version to use, a VersionRequest may fail. This is very unlikely, but could happen in theory.

Therefore it is helpful to implement a `--version` flag in the cli interface that prints the same information as VersionReponse:

```
$ ./build/dart-sass-embedded --version
{
  "protocol_version": "1.0.0-beta.12",
  "compiler_version": "1.0.0-beta.9",
  "implementation_version": "1.38.0",
  "implementation_name": "Dart Sass"
}
``` 

This would allow the host implementation to check and handle compatibility issues better. Host could also download the proper version of proto file and recompile as needed, etc.e