### PR TITLE
Don't return a CompileFailure without a span

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@
 
   * Allow `ImportResponse.result` to be null.
 
+* Fix a bug where the compiler could return a `CompileFailure` without a span.
+
 ## 1.0.0-beta.14
 
 * Support `FileImporter`s.

--- a/bin/dart_sass_embedded.dart
+++ b/bin/dart_sass_embedded.dart
@@ -5,6 +5,7 @@
 import 'dart:io';
 import 'dart:convert';
 
+import 'package:path/path.dart' as p;
 import 'package:sass/sass.dart' as sass;
 import 'package:stream_channel/stream_channel.dart';
 
@@ -100,7 +101,11 @@ void main(List<String> args) {
               ..failure = (OutboundMessage_CompileResponse_CompileFailure()
                 ..message = error.path == null
                     ? error.message
-                    : "${error.message}: ${error.path}");
+                    : "${error.message}: ${error.path}"
+                ..span = (SourceSpan()
+                  ..start = SourceSpan_SourceLocation()
+                  ..end = SourceSpan_SourceLocation()
+                  ..url = p.toUri(request.path).toString()));
           }
           break;
 

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,5 +1,5 @@
 name: sass_embedded
-version: 1.0.0-dev
+version: 1.0.0-beta.15
 description: An implementation of the Sass embedded protocol using Dart Sass.
 homepage: https://github.com/sass/dart-sass-embedded
 
@@ -12,6 +12,7 @@ executables:
 dependencies:
   async: ">=1.13.0 <3.0.0"
   meta: ^1.1.0
+  path: ^1.6.0
   protobuf: ^2.0.0
   sass: ^1.42.0
   sass_api: ^1.0.0-beta.5
@@ -24,7 +25,6 @@ dev_dependencies:
   cli_pkg: ^1.4.0
   grinder: ^0.9.0
   protoc_plugin: ^20.0.0
-  path: ^1.6.0
   test: ^1.0.0
   test_descriptor: ^2.0.0
   yaml: ^3.1.0

--- a/test/protocol_test.dart
+++ b/test/protocol_test.dart
@@ -300,7 +300,11 @@ void main() {
       expect(failure.message, startsWith("Cannot open file: "));
       expect(failure.message.replaceFirst("Cannot open file: ", "").trim(),
           equalsPath(d.path('test.scss')));
-      expect(failure.span, equals(SourceSpan()));
+      expect(failure.span.text, equals(''));
+      expect(failure.span.context, equals(''));
+      expect(failure.span.start, equals(SourceSpan_SourceLocation()));
+      expect(failure.span.end, equals(SourceSpan_SourceLocation()));
+      expect(failure.span.url, equals(p.toUri(d.path('test.scss')).toString()));
       expect(failure.stackTrace, isEmpty);
       await process.kill();
     });


### PR DESCRIPTION
We weren't adding a span for a compile failure due to a path not being
found. There's no real source in this situation, so we just create an
empty span instead.