### PR TITLE
Implement support for sourceMapIncludeSources

### DIFF
--- a/bin/dart_sass_embedded.dart
+++ b/bin/dart_sass_embedded.dart
@@ -119,7 +119,8 @@ void main(List<String> args) {
 
       var sourceMap = result.sourceMap;
       if (sourceMap != null) {
-        success.sourceMap = json.encode(sourceMap.toJson());
+        success.sourceMap = json.encode(sourceMap.toJson(
+            includeSourceContents: request.sourceMapIncludeSources));
       }
       return OutboundMessage_CompileResponse()..success = success;
     } on sass.SassException catch (error) {

--- a/test/protocol_test.dart
+++ b/test/protocol_test.dart
@@ -136,6 +136,48 @@ void main() {
           expect(span.start.line, equals(0));
           expect(span.start.column, equals(3));
           expect(span.end, equals(span.start));
+          expect(mapping, isA<source_maps.SingleMapping>());
+          expect((mapping as source_maps.SingleMapping).files[0], isNull);
+          return true;
+        })));
+    await process.kill();
+  });
+
+  test(
+      "includes a source map without content if source_map is true and source_map_include_sources is false",
+      () async {
+    process.inbound.add(compileString("a {b: 1px + 2px}",
+        sourceMap: true, sourceMapIncludeSources: false));
+    await expectLater(
+        process.outbound,
+        emits(isSuccess("a { b: 3px; }", sourceMap: (String map) {
+          var mapping = source_maps.parse(map);
+          var span = mapping.spanFor(2, 5)!;
+          expect(span.start.line, equals(0));
+          expect(span.start.column, equals(3));
+          expect(span.end, equals(span.start));
+          expect(mapping, isA<source_maps.SingleMapping>());
+          expect((mapping as source_maps.SingleMapping).files[0], isNull);
+          return true;
+        })));
+    await process.kill();
+  });
+
+  test(
+      "includes a source map with content if source_map is true and source_map_include_sources is true",
+      () async {
+    process.inbound.add(compileString("a {b: 1px + 2px}",
+        sourceMap: true, sourceMapIncludeSources: true));
+    await expectLater(
+        process.outbound,
+        emits(isSuccess("a { b: 3px; }", sourceMap: (String map) {
+          var mapping = source_maps.parse(map);
+          var span = mapping.spanFor(2, 5)!;
+          expect(span.start.line, equals(0));
+          expect(span.start.column, equals(3));
+          expect(span.end, equals(span.start));
+          expect(mapping, isA<source_maps.SingleMapping>());
+          expect((mapping as source_maps.SingleMapping).files[0], isNotNull);
           return true;
         })));
     await process.kill();

--- a/test/utils.dart
+++ b/test/utils.dart
@@ -20,6 +20,7 @@ InboundMessage compileString(String css,
     OutputStyle? style,
     String? url,
     bool? sourceMap,
+    bool? sourceMapIncludeSources,
     Iterable<InboundMessage_CompileRequest_Importer>? importers,
     InboundMessage_CompileRequest_Importer? importer,
     Iterable<String>? functions}) {
@@ -33,6 +34,9 @@ InboundMessage compileString(String css,
   if (importers != null) request.importers.addAll(importers);
   if (style != null) request.style = style;
   if (sourceMap != null) request.sourceMap = sourceMap;
+  if (sourceMapIncludeSources != null) {
+    request.sourceMapIncludeSources = sourceMapIncludeSources;
+  }
   if (functions != null) request.globalFunctions.addAll(functions);
   if (alertColor != null) request.alertColor = alertColor;
   if (alertAscii != null) request.alertAscii = alertAscii;


### PR DESCRIPTION
This needs https://github.com/sass/embedded-protocol/pull/87 to be merged first for the protocol. This PR implements this option in dart-sass-embedded.