### PR TITLE
Use dart analyze instead of the old dartanalyzer

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -85,7 +85,7 @@ jobs:
       - run: dart pub run grinder protobuf
         env: {UPDATE_SASS_PROTOCOL: false}
       - name: Analyze dart
-        run: dartanalyzer --fatal-warnings ./
+        run: dart analyze --fatal-warnings ./
 
   format:
     name: Code formatting


### PR DESCRIPTION
The old dartanalyzer does not take exclude rules into account properly for linting rules if the excluded file is also imported from a
non-excluded file (which is the case for the files generated by protobuf). The new tool does not suffer from this issue.

See https://github.com/sass/dart-sass-embedded/runs/4960189616?check_suite_focus=true#step:10:9 for an example reporting all those linting issues for the generated files (they don't fail the CI, but they are confusing in case something else makes the analyzer fail as they are still in the output)