### PR TITLE
Remove an unused import

### DIFF
--- a/test/dependencies_test.dart
+++ b/test/dependencies_test.dart
@@ -5,7 +5,6 @@
 import 'dart:io';
 
 import 'package:pubspec_parse/pubspec_parse.dart';
-import 'package:pub_semver/pub_semver.dart';
 import 'package:test/test.dart';
 
 /// This package's pubspec.


### PR DESCRIPTION
Combined with #70, this might allow to add `--fatal-infos` in the analyzer config if wanted by the maintainers.