### PR TITLE
Deploy linux arm64 release to github

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -119,7 +119,40 @@ jobs:
       - run: dart pub get
       - run: dart run grinder protobuf
       - name: Deploy
-        run: dart run grinder pkg-github-release pkg-github-linux
+        run: dart run grinder pkg-github-release pkg-github-linux-ia32 pkg-github-linux-x64
+        env: {GH_BEARER_TOKEN: "${{ github.token }}"}
+
+  deploy_github_linux_qemu:
+    name: "Deploy Github: Linux"
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        include:
+          # https://github.com/dart-lang/sdk/pull/48665
+          # - arch: arm
+          #   platform: linux/arm/v7
+          - arch: arm64
+            platform: linux/arm64
+    needs: [deploy_github_linux]
+    if: "startsWith(github.ref, 'refs/tags/') && github.repository == 'sass/dart-sass-embedded'"
+
+    steps:
+      - uses: actions/checkout@v2
+      - uses: arduino/setup-protoc@v1
+        with: { version: "${{ env.protoc_version }}", repo-token: "${{ github.token }}" }
+      - uses: dart-lang/setup-dart@v1
+      - run: dart pub get
+      - run: dart run grinder protobuf
+      - uses: docker/setup-qemu-action@v1
+      - name: Deploy
+        run: |
+          docker run --rm \
+            --env "GH_BEARER_TOKEN=$GH_BEARER_TOKEN" \
+            --platform ${{ matrix.platform }} \
+            --volume "$PWD:$PWD" \
+            --workdir "$PWD" \
+            docker.io/library/dart:latest \
+            /bin/sh -c "dart pub get && dart run grinder pkg-github-linux-${{ matrix.arch }}"
         env: {GH_BEARER_TOKEN: "${{ github.token }}"}
 
   deploy_github_macos:
@@ -159,7 +192,7 @@ jobs:
   release_embedded_host:
     name: "Release Embedded Host"
     runs-on: ubuntu-latest
-    needs: [deploy_github_linux, deploy_github_macos, deploy_github_windows]
+    needs: [deploy_github_linux, deploy_github_linux_qemu, deploy_github_macos, deploy_github_windows]
     if: "startsWith(github.ref, 'refs/tags/') && github.repository == 'sass/dart-sass-embedded'"
 
     steps:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -51,11 +51,11 @@ jobs:
         with: {repo: sass/embedded-protocol, path: build/embedded-protocol}
 
       - run: dart pub get
-      - run: dart pub run grinder protobuf
+      - run: dart run grinder protobuf
         env: {UPDATE_SASS_PROTOCOL: false}
-      - run: dart pub run grinder pkg-standalone-dev
+      - run: dart run grinder pkg-standalone-dev
       - name: Run tests
-        run: dart pub run test -r expanded
+        run: dart run test -r expanded
 
   static_analysis:
     name: Static analysis
@@ -90,7 +90,7 @@ jobs:
         with: {repo: sass/embedded-protocol, path: build/embedded-protocol}
 
       - run: dart pub get
-      - run: dart pub run grinder protobuf
+      - run: dart run grinder protobuf
         env: {UPDATE_SASS_PROTOCOL: false}
       - name: Analyze dart
         run: dart analyze --fatal-warnings ./
@@ -117,9 +117,9 @@ jobs:
         with: { version: "${{ env.protoc_version }}", repo-token: "${{ github.token }}" }
       - uses: dart-lang/setup-dart@v1
       - run: dart pub get
-      - run: dart pub run grinder protobuf
+      - run: dart run grinder protobuf
       - name: Deploy
-        run: dart pub run grinder pkg-github-release pkg-github-linux
+        run: dart run grinder pkg-github-release pkg-github-linux
         env: {GH_BEARER_TOKEN: "${{ github.token }}"}
 
   deploy_github_macos:
@@ -134,9 +134,9 @@ jobs:
         with: { version: "${{ env.protoc_version }}", repo-token: "${{ github.token }}" }
       - uses: dart-lang/setup-dart@v1
       - run: dart pub get
-      - run: dart pub run grinder protobuf
+      - run: dart run grinder protobuf
       - name: Deploy
-        run: dart pub run grinder pkg-github-macos
+        run: dart run grinder pkg-github-macos
         env: {GH_BEARER_TOKEN: "${{ github.token }}"}
 
   deploy_github_windows:
@@ -151,9 +151,9 @@ jobs:
         with: { version: "${{ env.protoc_version }}", repo-token: "${{ github.token }}" }
       - uses: dart-lang/setup-dart@v1
       - run: dart pub get
-      - run: dart pub run grinder protobuf
+      - run: dart run grinder protobuf
       - name: Deploy
-        run: dart pub run grinder pkg-github-windows
+        run: dart run grinder pkg-github-windows
         env: {GH_BEARER_TOKEN: "${{ github.token }}"}
 
   release_embedded_host:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -22,7 +22,7 @@ dependencies:
   typed_data: ^1.1.0
 
 dev_dependencies:
-  cli_pkg: ^1.4.0
+  cli_pkg: ^2.1.0
   grinder: ^0.9.0
   protoc_plugin: ^20.0.0
   test: ^1.0.0
@@ -31,4 +31,4 @@ dev_dependencies:
   pubspec_parse: ^1.0.0
   pub_semver: ^2.0.0
   sass_analysis:
-    git: {url: git://github.com/sass/dart-sass, path: analysis}
+    git: {url: https://github.com/sass/dart-sass.git, path: analysis}

--- a/tool/grind.dart
+++ b/tool/grind.dart
@@ -51,7 +51,7 @@ dart pub run protoc_plugin %*
   }
 
   if (Platform.environment['UPDATE_SASS_PROTOCOL'] != 'false') {
-    await cloneOrPull("git://github.com/sass/embedded-protocol");
+    await cloneOrPull("https://github.com/sass/embedded-protocol.git");
   }
 
   await runAsync("protoc",


### PR DESCRIPTION
This PR uses docker+qemu to build native arm64 release and push to github.

We can also use qemu to build native arm release but currently blocked by https://github.com/dart-lang/sdk/pull/48665 so I have leaved it commented out.