### PR TITLE
Set id on all OutboundMessage with id field

### DIFF
--- a/lib/src/dispatcher.dart
+++ b/lib/src/dispatcher.dart
@@ -227,11 +227,17 @@ class Dispatcher {
       case OutboundMessage_Message.importRequest:
         message.importRequest.id = id;
         break;
+      case OutboundMessage_Message.fileImportRequest:
+        message.fileImportRequest.id = id;
+        break;
       case OutboundMessage_Message.functionCallRequest:
         message.functionCallRequest.id = id;
         break;
-      default:
+      case OutboundMessage_Message.versionResponse:
+        message.versionResponse.id = id;
         break;
+      default:
+        throw ArgumentError("Unknown message type: ${message.toDebugString()}");
     }
   }
 

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,5 +1,5 @@
 name: sass_embedded
-version: 1.49.10
+version: 1.49.11-dev
 description: An implementation of the Sass embedded protocol using Dart Sass.
 homepage: https://github.com/sass/dart-sass-embedded
 


### PR DESCRIPTION
With multiple fileImportRequest that missing id (defaults to zero) send to host, the host will respond multiple times with id 0, causing `Response ID 0 doesn't match any outstanding requests.`

This PR add id to all known OutboundMessage types that needs an id field.

Note that this is not going to reproducible on the node host due to that the node host would start a new compiler process each time. But this causes parallel compile requests with FileImporter on the ruby host to crash.       