### PR TITLE
Treat null importer as noOp if url is not a file: url

### DIFF
--- a/bin/dart_sass_embedded.dart
+++ b/bin/dart_sass_embedded.dart
@@ -71,7 +71,8 @@ void main(List<String> args) {
               color: request.alertColor,
               logger: logger,
               importers: importers,
-              importer: _decodeImporter(dispatcher, request, input.importer),
+              importer: _decodeImporter(dispatcher, request, input.importer) ??
+                  (input.url.startsWith("file:") ? null : sass.Importer.noOp),
               functions: globalFunctions,
               syntax: syntaxToSyntax(input.syntax),
               style: style,


### PR DESCRIPTION
This PR fixes https://github.com/sass/dart-sass-embedded/issues/82.

See https://github.com/sass/sass-spec/pull/1785
See sass/embedded-host-node#128