### PR TITLE
Run qemu with tmpfs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -233,10 +233,12 @@ jobs:
           docker run --rm \
             --env "GH_BEARER_TOKEN=$GH_BEARER_TOKEN" \
             --platform ${{ matrix.platform }} \
-            --volume "$PWD:$PWD" \
+            --mount type=bind,source="$PWD",target="$PWD" \
+            --mount type=tmpfs,destination=/root/.pub-cache \
+            --mount type=tmpfs,destination=/tmp \
             --workdir "$PWD" \
             docker.io/library/dart:latest \
-            /bin/sh -c "dart pub get && dart run grinder pkg-github-linux-${{ matrix.arch }}"
+            /bin/sh -c "cp -R . /tmp/workspace && cd /tmp/workspace && dart pub get && dart run grinder pkg-github-linux-${{ matrix.arch }}"
         env: {GH_BEARER_TOKEN: "${{ github.token }}"}
 
   deploy_github_macos:


### PR DESCRIPTION
In testing https://github.com/sass/dart-sass-embedded/pull/88 locally (with 2.18 beta docker image), it hits a bug in qemu: https://gitlab.com/qemu-project/qemu/-/issues/263

The workaround to this bug is to run the build inside a tmpfs mount instead of a bind mount volume.