### PR TITLE
Revert "Run qemu with tmpfs (#89)"

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -260,12 +260,10 @@ jobs:
           docker run --rm \
             --env "GH_BEARER_TOKEN=$GH_BEARER_TOKEN" \
             --platform ${{ matrix.platform }} \
-            --mount type=bind,source="$PWD",target="$PWD" \
-            --mount type=tmpfs,destination=/root/.pub-cache \
-            --mount type=tmpfs,destination=/tmp \
+            --volume "$PWD:$PWD" \
             --workdir "$PWD" \
             docker.io/library/dart:latest \
-            /bin/sh -c "cp -R . /tmp/workspace && cd /tmp/workspace && dart pub get && dart run grinder pkg-github-linux-${{ matrix.arch }}"
+            /bin/sh -c "dart pub get && dart run grinder pkg-github-linux-${{ matrix.arch }}"
         env: {GH_BEARER_TOKEN: "${{ github.token }}"}
 
   deploy_github:


### PR DESCRIPTION
This reverts commit 3d442b402b27f6c6224f28ed08e13fc24bff36fa.

The fix for the original issue is in https://github.com/dart-lang/sdk/commit/6b04565db2a345867e7ecf56e838321cc85a4e28 and has been included with dart-sdk `2.18.0-271.2.beta`. I have tested it locally and verified the workaround is no longer needed.