### PR TITLE
Stop trying to build ARM64 for now

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -277,9 +277,10 @@ jobs:
       matrix:
         include:
           - runner: macos-latest
-            platform: macos-x64
-          - runner: self-hosted
-            platform: macos-arm64
+            platform: macos # Make this "macos-x64" when we separate out "macos-arm64"
+          # arduino/setup-protoc doesn't support ARM64 (arduino/setup-protoc#26)
+          # - runner: self-hosted
+          #   platform: macos-arm64
           - runner: windows-latest
             platform: windows
 


### PR DESCRIPTION
This is currently blocked on arduino/setup-protoc#26 as well as
support for Node 16 in that action.

See #90