### PR TITLE
Update optional dependency versions in embedded-host-node

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -318,8 +318,8 @@ jobs:
           cat package.json |
               jq --arg version ${{ steps.version.outputs.version }} '
                 .version |= $version |
-                ."compiler-version" |= $version
-                optionalDependencies = (.optionalDependencies | .[] |= $version)
+                ."compiler-version" |= $version |
+                .optionalDependencies = (.optionalDependencies | .[] |= $version)
               ' > package.json.tmp &&
             mv package.json.tmp package.json
           curl https://raw.githubusercontent.com/sass/dart-sass/${{ steps.version.outputs.version }}/CHANGELOG.md > CHANGELOG.md

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -319,6 +319,7 @@ jobs:
               jq --arg version ${{ steps.version.outputs.version }} '
                 .version |= $version |
                 ."compiler-version" |= $version
+                optionalDependencies = (.optionalDependencies | .[] |= $version)
               ' > package.json.tmp &&
             mv package.json.tmp package.json
           curl https://raw.githubusercontent.com/sass/dart-sass/${{ steps.version.outputs.version }}/CHANGELOG.md > CHANGELOG.md


### PR DESCRIPTION
This is needed by sass/embedded-host-node#158 to properly release new
versions of the embedded host.