### PR TITLE
fix: update optional dependencies version in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -321,6 +321,16 @@ jobs:
 
       - name: Update version
         run: |
+          find "npm" -mindepth 1 -maxdepth 1 -type d | while read -r dir
+            do
+              pushd "$dir"
+                cat package.json |
+                    jq --arg version ${{ steps.version.outputs.version }} '
+                      .version |= $version
+                    ' > package.json.tmp &&
+                  mv package.json.tmp package.json
+              popd
+            done
           cat package.json |
               jq --arg version ${{ steps.version.outputs.version }} '
                 .version |= $version |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -321,16 +321,16 @@ jobs:
 
       - name: Update version
         run: |
-          find "npm" -mindepth 1 -maxdepth 1 -type d | while read -r dir
-            do
-              pushd "$dir"
-                cat package.json |
-                    jq --arg version ${{ steps.version.outputs.version }} '
-                      .version |= $version
-                    ' > package.json.tmp &&
-                  mv package.json.tmp package.json
-              popd
-            done
+          # Update binary package versions
+          for dir in $(ls npm); do
+            cat "npm/$dir/package.json" |
+                jq --arg version ${{ steps.version.outputs.version }} '
+                  .version |= $version
+                ' > package.json.tmp &&
+              mv package.json.tmp ""npm/$dir/package.json"
+          done
+
+          # Update main package version and dependencies on binary packages
           cat package.json |
               jq --arg version ${{ steps.version.outputs.version }} '
                 .version |= $version |


### PR DESCRIPTION
For now, `sassbot` will only update the optionalDependencies version for `sass-embedded`'s package.json, but didn't update the package's version under the npm directory. This PR fixes this.