### PR TITLE
Do not shutdown when throwing PARAMS error

### DIFF
--- a/lib/src/dispatcher.dart
+++ b/lib/src/dispatcher.dart
@@ -103,9 +103,11 @@ class Dispatcher {
         if (error.id != errorId) stderr.write(" with request ${error.id}");
         stderr.writeln(": ${error.message}");
         sendError(error);
-        // PROTOCOL error from https://bit.ly/2poTt90
-        exitCode = 76;
-        _channel.sink.close();
+        if (error.type != ProtocolErrorType.PARAMS) {
+          // PROTOCOL error from https://bit.ly/2poTt90
+          exitCode = 76;
+          _channel.sink.close();
+        }
       } catch (error, stackTrace) {
         var errorMessage = "$error\n${Chain.forTrace(stackTrace)}";
         stderr.write("Internal compiler error: $errorMessage");


### PR DESCRIPTION
PARAMS error is always per compilation, we shouldn't need to shutdown the whole compiler. The motivation is that when the host sends multiple requests, crashing the compiler just for 1 params error will cause other requests to fail as well, leading to a bad user experience.