### PR TITLE
Reformat pubspec.yaml

### DIFF
--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -32,4 +32,6 @@ dev_dependencies:
   pubspec_parse: ^1.0.0
   pub_semver: ^2.0.0
   sass_analysis:
-    git: {url: https://github.com/sass/dart-sass.git, path: analysis}
+    git:
+      url: https://github.com/sass/dart-sass.git
+      path: analysis


### PR DESCRIPTION
This allows more strict yaml parser (not from dart) to parse the `pubspec.yaml`.

This is for https://github.com/sass/homebrew-sass/pull/49/files#diff-6d5314093ad5c764ed77fcb89775eebf909f543043bdc2e69d9b8ecdef3e859fR43-R47