### PR TITLE
Fix dart analyze issues

### DIFF
--- a/lib/src/importer/base.dart
+++ b/lib/src/importer/base.dart
@@ -25,7 +25,7 @@ abstract class ImporterBase extends sass.Importer {
     Uri parsedUrl;
     try {
       parsedUrl = Uri.parse(url);
-    } on FormatException catch (error) {
+    } on FormatException {
       throw '$source must return a URL, was "$url"';
     }
 

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -368,7 +368,7 @@ packages:
     source: hosted
     version: "2.1.1"
   source_maps:
-    dependency: transitive
+    dependency: "direct dev"
     description:
       name: source_maps
       url: "https://pub.dartlang.org"

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -31,3 +31,4 @@ dev_dependencies:
     git:
       url: https://github.com/sass/dart-sass.git
       path: analysis
+  source_maps: ^0.10.10


### PR DESCRIPTION
This PR fixes the following:

```
Analyzing dart-sass-embedded...        0.9s

   info • lib/src/importer/base.dart:28:33 • The exception variable 'error' isn't used, so the 'catch' clause can be removed. Try removing the catch clause. • unused_catch_clause
   info • test/importer_test.dart:5:8 • Depend on referenced packages. • depend_on_referenced_packages
   info • test/protocol_test.dart:7:8 • Depend on referenced packages. • depend_on_referenced_packages

3 issues found.
```