### PR TITLE
Replace waitFor with async/await

### DIFF
--- a/bin/dart_sass_embedded.dart
+++ b/bin/dart_sass_embedded.dart
@@ -63,8 +63,7 @@ void main(List<String> args) {
         case InboundMessage_CompileRequest_Input.string:
           var input = request.string;
           sass.AsyncImporter? importer =
-              _decodeImporter(dispatcher, request, input.importer) ??
-                  (input.url.startsWith("file:") ? null : sass.Importer.noOp);
+              _decodeImporter(dispatcher, request, input.importer);
           if (importer == null &&
               importers.isEmpty &&
               globalFunctions.isEmpty) {
@@ -72,7 +71,8 @@ void main(List<String> args) {
                 color: request.alertColor,
                 logger: logger,
                 importers: [],
-                importer: null,
+                importer:
+                    input.url.startsWith("file:") ? null : sass.Importer.noOp,
                 functions: [],
                 syntax: syntaxToSyntax(input.syntax),
                 style: style,
@@ -86,7 +86,8 @@ void main(List<String> args) {
                 color: request.alertColor,
                 logger: logger,
                 importers: importers,
-                importer: importer,
+                importer: importer ??
+                    (input.url.startsWith("file:") ? null : sass.Importer.noOp),
                 functions: globalFunctions,
                 syntax: syntaxToSyntax(input.syntax),
                 style: style,

--- a/lib/src/dispatcher.dart
+++ b/lib/src/dispatcher.dart
@@ -41,12 +41,6 @@ class Dispatcher {
       FutureOr<OutboundMessage_CompileResponse> callback(
           InboundMessage_CompileRequest request)) {
     _channel.stream.listen((binaryMessage) async {
-      // Wait a single microtask tick so that we're running in a separate
-      // microtask from the initial request dispatch. Otherwise, [waitFor] will
-      // deadlock the event loop fiber that would otherwise be checking stdin
-      // for new input.
-      await Future<void>.value();
-
       InboundMessage? message;
       try {
         try {

--- a/lib/src/host_callable.dart
+++ b/lib/src/host_callable.dart
@@ -2,8 +2,6 @@
 // MIT-style license that can be found in the LICENSE file or at
 // https://opensource.org/licenses/MIT.
 
-// ignore: deprecated_member_use
-import 'dart:cli';
 import 'dart:io';
 
 import 'package:sass_api/sass_api.dart' as sass;
@@ -22,11 +20,11 @@ import 'utils.dart';
 /// the name defined in the [signature].
 ///
 /// Throws a [sass.SassException] if [signature] is invalid.
-sass.Callable hostCallable(Dispatcher dispatcher, FunctionRegistry functions,
-    int compilationId, String signature,
+sass.AsyncCallable hostCallable(Dispatcher dispatcher,
+    FunctionRegistry functions, int compilationId, String signature,
     {int? id}) {
-  late sass.Callable callable;
-  callable = sass.Callable.fromSignature(signature, (arguments) {
+  late sass.AsyncCallable callable;
+  callable = sass.AsyncCallable.fromSignature(signature, (arguments) async {
     var protofier = Protofier(dispatcher, functions, compilationId);
     var request = OutboundMessage_FunctionCallRequest()
       ..compilationId = compilationId
@@ -39,8 +37,7 @@ sass.Callable hostCallable(Dispatcher dispatcher, FunctionRegistry functions,
       request.name = callable.name;
     }
 
-    // ignore: deprecated_member_use
-    var response = waitFor(dispatcher.sendFunctionCallRequest(request));
+    var response = await dispatcher.sendFunctionCallRequest(request);
     try {
       switch (response.whichResult()) {
         case InboundMessage_FunctionCallResponse_Result.success:

--- a/lib/src/importer/base.dart
+++ b/lib/src/importer/base.dart
@@ -9,7 +9,7 @@ import '../dispatcher.dart';
 
 /// An abstract base class for importers that communicate with the host in some
 /// way.
-abstract class ImporterBase extends sass.Importer {
+abstract class ImporterBase extends sass.AsyncImporter {
   /// The [Dispatcher] to which to send requests.
   @protected
   final Dispatcher dispatcher;

--- a/lib/src/importer/file.dart
+++ b/lib/src/importer/file.dart
@@ -2,8 +2,7 @@
 // MIT-style license that can be found in the LICENSE file or at
 // https://opensource.org/licenses/MIT.
 
-// ignore: deprecated_member_use
-import 'dart:cli';
+import 'dart:async';
 
 import 'package:sass_api/sass_api.dart' as sass;
 
@@ -29,11 +28,10 @@ class FileImporter extends ImporterBase {
   FileImporter(Dispatcher dispatcher, this._compilationId, this._importerId)
       : super(dispatcher);
 
-  Uri? canonicalize(Uri url) {
+  FutureOr<Uri?> canonicalize(Uri url) {
     if (url.scheme == 'file') return _filesystemImporter.canonicalize(url);
 
-    // ignore: deprecated_member_use
-    return waitFor(() async {
+    return (() async {
       var response = await dispatcher
           .sendFileImportRequest(OutboundMessage_FileImportRequest()
             ..compilationId = _compilationId

--- a/lib/src/importer/host.dart
+++ b/lib/src/importer/host.dart
@@ -2,8 +2,7 @@
 // MIT-style license that can be found in the LICENSE file or at
 // https://opensource.org/licenses/MIT.
 
-// ignore: deprecated_member_use
-import 'dart:cli';
+import 'dart:async';
 
 import 'package:sass_api/sass_api.dart' as sass;
 
@@ -23,9 +22,8 @@ class HostImporter extends ImporterBase {
   HostImporter(Dispatcher dispatcher, this._compilationId, this._importerId)
       : super(dispatcher);
 
-  Uri? canonicalize(Uri url) {
-    // ignore: deprecated_member_use
-    return waitFor(() async {
+  FutureOr<Uri?> canonicalize(Uri url) {
+    return (() async {
       var response = await dispatcher
           .sendCanonicalizeRequest(OutboundMessage_CanonicalizeRequest()
             ..compilationId = _compilationId
@@ -46,9 +44,8 @@ class HostImporter extends ImporterBase {
     }());
   }
 
-  sass.ImporterResult? load(Uri url) {
-    // ignore: deprecated_member_use
-    return waitFor(() async {
+  FutureOr<sass.ImporterResult?> load(Uri url) {
+    return (() async {
       var response =
           await dispatcher.sendImportRequest(OutboundMessage_ImportRequest()
             ..compilationId = _compilationId


### PR DESCRIPTION
This PR replaces waitFor with async/await.

~~There's some trade off in terms of performance, see benchmark below. Personally I think this trade off is worth it as in most of the cases the performance is getting better.~~

~~Update: Added a commit to fix regression. Performance is now either nearly equal or way better in every case. The code logic isn't really changed from the first attempt, but dart's compiler seems to have trouble optimize the old one correctly due to how type inference works.~~

Update 2: still regress a lot in another case, see comment below.

- Fixes sass/dart-sass#1959

Baseline 1.57.1 waitFor:

```
       user     system      total        real
 1c start up cost  0.000184   0.000801   0.000985 (  0.022070)
1t/100c bootstrap  0.021838   0.021640   0.043478 ( 15.298093)
1t/100000c w/  func w/  url  4.891331   1.683478   6.574809 ( 21.760007)
4t/100000c w/  func w/  url  4.863213   1.674371   6.537584 ( 21.683645)
1t/100000c w/  func w/o url  4.709930   1.602782   6.312712 ( 19.915833)
4t/100000c w/  func w/o url  4.722000   1.590509   6.312509 ( 19.854262)
1t/100000c w/o func w/  url  2.131774   0.488197   2.619971 ( 12.001358)
4t/100000c w/o func w/  url  2.124635   0.487802   2.612437 ( 11.982604)
1t/100000c w/o func w/o url  2.073813   0.497656   2.571469 ( 10.536980)
4t/100000c w/o func w/o url  2.082869   0.506721   2.589590 ( 10.585789)
ruby test.rb  104.23s user 39.80s system 100% cpu 2:23.72 total
```

This PR 1.57.1 async/await:

```
       user     system      total        real
 1c start up cost  0.000259   0.000981   0.001240 (  0.024843)           # (smaller is better)
1t/100c bootstrap  0.021841   0.021375   0.043216 ( 15.391264)           # 1.006x 
1t/100000c w/  func w/  url  4.081550   1.060135   5.141685 ( 18.881023) # 0.868x
4t/100000c w/  func w/  url  4.082645   1.058004   5.140649 ( 18.870283) # 0.870x
1t/100000c w/  func w/o url  4.037197   1.063087   5.100284 ( 17.276619) # 0.867x
4t/100000c w/  func w/o url  4.040086   1.064021   5.104107 ( 17.267876) # 0.870x
1t/100000c w/o func w/  url  2.149704   0.511046   2.660750 ( 12.137423) # 1.011x
4t/100000c w/o func w/  url  2.144795   0.512078   2.656873 ( 12.132177) # 1.012x
1t/100000c w/o func w/o url  2.098397   0.505022   2.603419 ( 10.608703) # 1.006x
4t/100000c w/o func w/o url  2.088623   0.505967   2.594590 ( 10.606887) # 1.002x
ruby test.rb  99.62s user 27.62s system 95% cpu 2:13.28 total            # 0.927x
```

Both tests are compiled locally with same dart version:
```
pkg-compile-native
  dart compile aot-snapshot bin/dart_sass_embedded.dart -Dversion=1.57.1 -Ddart-version=2.18.6 -Dprotocol-version=1.2.0 -Dcompiler-version=1.57.1 -Dimplementation-version=1.57.1 --output build/dart-sass-embedded.native
```

Benchmark code:

``` ruby
require_relative './lib/sass-embedded'
require 'benchmark'

c = 100000

Benchmark.bm do |x|
  x.report ' 1c start up cost' do
    Sass.info
  end
  x.report '1t/100c bootstrap' do
    100.times do
      Sass.compile('./node_modules/bootstrap/scss/bootstrap.scss').css
    end
  end
  [true, false].each do |f|
    [true, false].each do |u|
      [1, 4].each do |t|
        x.report "#{t}t/#{c}c #{f ? 'w/ ' : 'w/o'} func #{u ? 'w/ ' : 'w/o'} url" do
          input = f ? 'a {b: foo()}' : 'a {b: c}'
          args = ({})
            .merge!(f ? {functions: {
              'foo()': ->(_) { Sass::Value::String.new('bar') }
            }} : {})
            .merge!(u ? {url: 'file:///tmp/test.scss'} : {})

          t.times do
            threads = []
            threads << Thread.new do
              (c / t).times do
                Sass.compile_string(input, **args).css
              end
            end
            threads.each(&:join)
          end
        end
      end
    end
  end
end
```