### PR TITLE
Install protoc from @protobuf-ts/protoc

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,7 +25,8 @@ jobs:
       - uses: actions/checkout@v3
       - uses: frenck/action-setup-yq@v1
         with: {version: v4.30.5} # frenck/action-setup-yq#35
-      - run: npm install --global @protobuf-ts/protoc
+      - uses: bufbuild/buf-setup-action@v1.13.1
+        with: {github_token: "${{ github.token }}"}
       - uses: dart-lang/setup-dart@v1
         with: {sdk: "${{ matrix.dart_channel }}"}
 
@@ -82,7 +83,8 @@ jobs:
         with: {sdk: stable}
       - uses: frenck/action-setup-yq@v1
         with: {version: v4.30.5} # frenck/action-setup-yq#35
-      - run: npm install --global @protobuf-ts/protoc
+      - uses: bufbuild/buf-setup-action@v1.13.1
+        with: {github_token: "${{ github.token }}"}
 
       - name: Check out Dart Sass only if linked in the PR description
         uses: sass/clone-linked-repo@v1
@@ -154,7 +156,8 @@ jobs:
       - uses: actions/checkout@v3
       - uses: frenck/action-setup-yq@v1
         with: {version: v4.30.5} # frenck/action-setup-yq#35
-      - run: npm install --global @protobuf-ts/protoc
+      - uses: bufbuild/buf-setup-action@v1.13.1
+        with: {github_token: "${{ github.token }}"}
       - uses: dart-lang/setup-dart@v1
 
       - name: Check out Dart Sass only if linked in the PR description
@@ -202,8 +205,8 @@ jobs:
 
     steps:
       - uses: actions/checkout@v3
-      - name: Install protoc
-        run: npm install --global @protobuf-ts/protoc
+      - uses: bufbuild/buf-setup-action@v1.13.1
+        with: {github_token: "${{ github.token }}"}
       - uses: dart-lang/setup-dart@v1
       - run: dart pub get
       - run: dart run grinder protobuf
@@ -226,7 +229,8 @@ jobs:
 
     steps:
       - uses: actions/checkout@v3
-      - run: npm install --global @protobuf-ts/protoc
+      - uses: bufbuild/buf-setup-action@v1.13.1
+        with: {github_token: "${{ github.token }}"}
       - run: dart pub get
       - run: dart pub grinder protobuf
       - uses: docker/setup-qemu-action@v2
@@ -261,7 +265,8 @@ jobs:
 
     steps:
       - uses: actions/checkout@v3
-      - run: npm install --global @protobuf-ts/protoc
+      - uses: bufbuild/buf-setup-action@v1.13.1
+        with: {github_token: "${{ github.token }}"}
       - uses: dart-lang/setup-dart@v1
         # Workaround for dart-lang/setup-dart#59
         with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,9 +3,6 @@ name: CI
 defaults:
   run: {shell: bash}
 
-env:
-  protoc_version: '3.x'
-
 on:
   push:
     branches: [main, feature.*]
@@ -28,8 +25,7 @@ jobs:
       - uses: actions/checkout@v3
       - uses: frenck/action-setup-yq@v1
         with: {version: v4.30.5} # frenck/action-setup-yq#35
-      - uses: arduino/setup-protoc@v1
-        with: { version: "${{ env.protoc_version }}", repo-token: "${{ github.token }}" }
+      - run: npm install --global @protobuf-ts/protoc
       - uses: dart-lang/setup-dart@v1
         with: {sdk: "${{ matrix.dart_channel }}"}
 
@@ -86,10 +82,7 @@ jobs:
         with: {sdk: stable}
       - uses: frenck/action-setup-yq@v1
         with: {version: v4.30.5} # frenck/action-setup-yq#35
-      - uses: arduino/setup-protoc@v1
-        with:
-          version: ${{ env.PROTOC_VERSION }}
-          repo-token: '${{ github.token }}'
+      - run: npm install --global @protobuf-ts/protoc
 
       - name: Check out Dart Sass only if linked in the PR description
         uses: sass/clone-linked-repo@v1
@@ -161,8 +154,7 @@ jobs:
       - uses: actions/checkout@v3
       - uses: frenck/action-setup-yq@v1
         with: {version: v4.30.5} # frenck/action-setup-yq#35
-      - uses: arduino/setup-protoc@v1
-        with: { version: "${{ env.protoc_version }}", repo-token: "${{ github.token }}" }
+      - run: npm install --global @protobuf-ts/protoc
       - uses: dart-lang/setup-dart@v1
 
       - name: Check out Dart Sass only if linked in the PR description
@@ -210,20 +202,11 @@ jobs:
 
     steps:
       - uses: actions/checkout@v3
-      - uses: arduino/setup-protoc@v1
-        with: { version: "${{ env.protoc_version }}", repo-token: "${{ github.token }}" }
+      - name: Install protoc
+        run: npm install --global @protobuf-ts/protoc
       - uses: dart-lang/setup-dart@v1
       - run: dart pub get
       - run: dart run grinder protobuf
-      # We need to upload the compiled protobuf rather than recompiling it on
-      # other platforms because arduino/setup-protoc currently) requires Node 12
-      # which doesn't support ARM.
-      - uses: actions/upload-artifact@v3
-        with:
-          name: embedded-protocol
-          path: |
-            build/embedded-protocol
-            lib/src/embedded_sass.*.dart
       - name: Deploy
         run: dart run grinder pkg-github-release pkg-github-linux-ia32 pkg-github-linux-x64
         env: {GH_BEARER_TOKEN: "${{ github.token }}"}
@@ -243,9 +226,9 @@ jobs:
 
     steps:
       - uses: actions/checkout@v3
-      - uses: actions/download-artifact@v3
-        with:
-          name: embedded-protocol
+      - run: npm install --global @protobuf-ts/protoc
+      - run: dart pub get
+      - run: dart pub grinder protobuf
       - uses: docker/setup-qemu-action@v2
       - name: Deploy
         run: |
@@ -278,14 +261,13 @@ jobs:
 
     steps:
       - uses: actions/checkout@v3
-      - uses: actions/download-artifact@v3
-        with:
-          name: embedded-protocol
+      - run: npm install --global @protobuf-ts/protoc
       - uses: dart-lang/setup-dart@v1
         # Workaround for dart-lang/setup-dart#59
         with:
           architecture: ${{ matrix.architecture }}
       - run: dart pub get
+      - run: dart pub run grinder protobuf
       - name: Deploy
         run: dart run grinder pkg-github-${{ matrix.platform }}
         env: {GH_BEARER_TOKEN: "${{ github.token }}"}

--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ From there, you can either run `dart bin/dart_sass_embedded.dart` directly or
 `dart run grinder pkg-standalone-dev` to build a compiled development
 executable.
 
-[install `buf`]: https://docs.buf.build/installation
+[Install `buf`]: https://docs.buf.build/installation
 
 ### Releases
 

--- a/README.md
+++ b/README.md
@@ -13,6 +13,22 @@ and importers.
 - `dart-sass-embedded` starts the compiler and listens on stdin.
 - `dart-sass-embedded --version` prints `versionResponse` with `id = 0` in JSON and exits.
 
+### Development
+
+To run the embedded compiler from source:
+
+* Run `dart pub get`.
+
+* [Install `buf`].
+
+* Run `dart run grinder protobuf`.
+
+From there, you can either run `dart bin/dart_sass_embedded.dart` directly or
+`dart run grinder pkg-standalone-dev` to build a compiled development
+executable.
+
+[install `buf`]: https://docs.buf.build/installation
+
 ### Releases
 
 Binary releases are available from the [GitHub release page]. We recommend that

--- a/buf.gen.yaml
+++ b/buf.gen.yaml
@@ -1,0 +1,4 @@
+version: v1
+plugins:
+- plugin: dart
+  out: lib/src

--- a/buf.work.yaml
+++ b/buf.work.yaml
@@ -1,0 +1,2 @@
+version: v1
+directories: [build/embedded-protocol]

--- a/tool/grind.dart
+++ b/tool/grind.dart
@@ -51,11 +51,14 @@ Future<void> protobuf() async {
   if (Platform.isWindows) {
     File('build/protoc-gen-dart.bat').writeAsStringSync('''
 @echo off
-dart pub run protoc_plugin %*
+dart run protoc_plugin %*
 ''');
   } else {
     File('build/protoc-gen-dart')
-        .writeAsStringSync('dart pub run protoc_plugin "\$@"');
+        .writeAsStringSync('''
+#!/bin/sh
+dart run protoc_plugin "\$@"
+''');
     run('chmod', arguments: ['a+x', 'build/protoc-gen-dart']);
   }
 
@@ -63,12 +66,8 @@ dart pub run protoc_plugin %*
     await cloneOrPull("https://github.com/sass/embedded-protocol.git");
   }
 
-  await runAsync("protoc",
-      arguments: [
-        "-Ibuild/embedded-protocol",
-        "embedded_sass.proto",
-        "--dart_out=lib/src/"
-      ],
+  await runAsync("buf",
+      arguments: ["generate"],
       runOptions: RunOptions(environment: {
         "PATH": 'build' +
             (Platform.isWindows ? ";" : ":") +

--- a/tool/grind.dart
+++ b/tool/grind.dart
@@ -54,8 +54,7 @@ Future<void> protobuf() async {
 dart run protoc_plugin %*
 ''');
   } else {
-    File('build/protoc-gen-dart')
-        .writeAsStringSync('''
+    File('build/protoc-gen-dart').writeAsStringSync('''
 #!/bin/sh
 dart run protoc_plugin "\$@"
 ''');


### PR DESCRIPTION
This is more consistent with the embedded host, and avoids relying on
the seldom-maintaned arduino/setup-protoc GitHub action.