### PR TITLE
Add missing setup-dart step in qemu release

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -231,6 +231,7 @@ jobs:
       - uses: actions/checkout@v3
       - uses: bufbuild/buf-setup-action@v1.13.1
         with: {github_token: "${{ github.token }}"}
+      - uses: dart-lang/setup-dart@v1
       - run: dart pub get
       - run: dart pub grinder protobuf
       - uses: docker/setup-qemu-action@v2


### PR DESCRIPTION
This used to be just download artifact so that dart installation was not needed, but now we are building protobuf we need dart to be installed.